### PR TITLE
Initialize `jirehgrp` CLI project — starting at version 0.0.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 JirehGroup
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,21 +1,84 @@
 {
-  "name": "jirehgrp-cli",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "name": "jirehgrp",
+  "version": "0.0.1",
+  "description": "Scaffold frontend apps from Jireh templates (Next.js, React+Vite, Vanilla, etc.)",
+  "bin": {
+    "jirehgrp": "dist/index.js"
   },
+  "license": "MIT",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -w",
+    "release": "standard-version",
+    "release:minor": "standard-version --release-as minor",
+    "release:major": "standard-version --release-as major",
+    "tree": "ts-node test-tree.ts"
+  },
+  "keywords": [
+    "amharic",
+    "english",
+    "multilingual",
+    "scaffold",
+    "cli",
+    "cli-tool",
+    "frontend",
+    "starter",
+    "starter-template",
+    "boilerplate",
+    "templates",
+    "vite",
+    "nextjs",
+    "react",
+    "vue",
+    "vue3",
+    "svelte",
+    "sveltekit",
+    "vanilla",
+    "typescript",
+    "javascript",
+    "theme",
+    "dark mode",
+    "light mode",
+    "package manager",
+    "git",
+    "degit",
+    "project generator",
+    "tree"
+  ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jirehgrp-org/jirehgrp-cli.git"
+    "url": "https://github.com/jirehgrp-org/jirehgrp-cli.git"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "type": "commonjs",
   "bugs": {
     "url": "https://github.com/jirehgrp-org/jirehgrp-cli/issues"
   },
-  "homepage": "https://github.com/jirehgrp-org/jirehgrp-cli#readme"
+  "homepage": "https://github.com/jirehgrp-org/jirehgrp-cli#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "preferGlobal": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "degit": "^2.8.4",
+    "execa": "^9.3.0",
+    "kleur": "^4.1.5",
+    "minimist": "^1.2.8",
+    "ora": "^8.0.1",
+    "prompts": "^2.4.2"
+  },
+  "devDependencies": {
+    "@types/degit": "^2.8.6",
+    "@types/minimatch": "^5.1.2",
+    "@types/minimist": "^1.2.5",
+    "@types/node": "^24.2.1",
+    "@types/prompts": "^2.4.9",
+    "standard-version": "^9.5.0",
+    "typescript": "^5.5.0"
+  }
 }

--- a/src/fetchTemplate.ts
+++ b/src/fetchTemplate.ts
@@ -1,0 +1,30 @@
+// src/fetchTemplate.ts
+
+import degit from "degit";
+import path from "node:path";
+import fs from "node:fs";
+
+export async function copyTemplate(
+  repoRef: string,
+  subdir: string | undefined,
+  dest: string
+) {
+  const tmp = path.join(dest, ".jireh-tmp");
+  await degit(repoRef, { cache: false, force: true }).clone(tmp);
+
+  const from = subdir ? path.join(tmp, subdir) : tmp;
+
+  if (!fs.existsSync(from)) {
+    throw new Error(`Subdir not found in template: ${from}`);
+  }
+
+  const entries = fs.readdirSync(from);
+  for (const name of entries) {
+    fs.cpSync(path.join(from, name), path.join(dest, name), {
+      recursive: true,
+      force: true,
+    });
+  }
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// src/index.ts
+
+import path from "node:path";
+import fs from "node:fs";
+import minimist from "minimist";
+import kleur from "kleur";
+import ora from "ora";
+import { ask } from "./prompts.js";
+import { registry } from "./registry.js";
+import { copyTemplate } from "./fetchTemplate.js";
+import { finalizeProject } from "./postInstall.js";
+import { buildTreeString, writeTreeToFile } from "./tree.js"
+
+const argv = minimist(process.argv.slice(2), {
+  string: ["template", "name", "tag", "dir", "pm"],
+  boolean: ["install", "git", "yes", "tree"],
+  default: { install: undefined, git: undefined, tree: false },
+});
+
+function getProjectName(dir: string): string {
+  try {
+    const pkgJsonPath = path.join(dir, "package.json");
+    if (fs.existsSync(pkgJsonPath)) {
+      const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+      if (pkg.name) return pkg.name;
+    }
+  } catch {
+    // ignore error and fallback below
+  }
+  return path.basename(dir);
+}
+
+function prefixTreeWithRootName(treeStr: string, rootName: string): string {
+  const indent = '│   ';
+  const lines = treeStr.split('\n').filter(Boolean);
+  const indentedLines = lines.map(line => indent + line);
+  return `${rootName}/\n${indentedLines.join('\n')}\n`;
+}
+
+(async () => {
+  if (argv.tree) {
+    const dirToPrint = path.resolve(process.cwd(), argv.dir || ".");
+    const rootName = getProjectName(dirToPrint);
+    const fullTreeColored = buildTreeString(dirToPrint, '', { color: true });
+
+    console.log(kleur.bold(`\nProject structure for: ${dirToPrint}`));
+    console.log(kleur.bold(`Generating project structure for: ${dirToPrint}\n`));
+
+    const treeWithRoot = `${rootName}/\n${fullTreeColored}`;
+    const treeLines = treeWithRoot.trim().split('\n');
+    const snippetLimit = 30;
+    if (treeLines.length > snippetLimit) {
+      console.log(treeLines.slice(0, snippetLimit).join('\n'));
+      console.log(kleur.gray(`\n...snipped ${treeLines.length - snippetLimit} lines...\n`));
+    } else {
+      console.log(treeWithRoot);
+    }
+
+    const structurePath = path.join(dirToPrint, 'structure.txt');
+    const projectStructurePath = path.join(dirToPrint, 'project_structure.txt');
+    const filePathToWrite = fs.existsSync(structurePath) ? projectStructurePath : structurePath;
+    const plainTree = buildTreeString(dirToPrint, '', { color: false });
+    const plainWithRoot = `${rootName}/\n${plainTree}`;
+
+    fs.writeFileSync(filePathToWrite, plainWithRoot);
+
+    console.log(kleur.green(`Project structure mapped and written.`));
+    console.log(kleur.green(`Check it out at: ${filePathToWrite}\n`));
+    process.exit(0);
+  }
+
+
+  const answers = await ask({
+    name: argv.name,
+    templateKey: argv.template as any,
+    install: argv.install,
+    git: argv.git,
+  });
+
+  const dest = path.resolve(process.cwd(), argv.dir ?? answers.name);
+
+  if (fs.existsSync(dest) && fs.readdirSync(dest).length > 0) {
+    if (!argv.yes) {
+      console.error(kleur.red(`\nError: Target directory '${dest}' is not empty.`));
+      console.log(
+        kleur.yellow(
+          `\nTip: Re-run with ${kleur.bold("--yes")} to overwrite, or choose an empty folder.\n`
+        )
+      );
+      process.exit(1);
+    }
+  }
+  fs.mkdirSync(dest, { recursive: true });
+
+  const entry = registry[answers.templateKey];
+  const repoRef = argv.tag ? `${entry.repo.split("#")[0]}#${argv.tag}` : entry.repo;
+
+  const spin = ora(`Fetching ${entry.label} ...`).start();
+  try {
+    await copyTemplate(repoRef, entry.subdir, dest);
+    spin.succeed("Template copied");
+  } catch (e) {
+    spin.fail("Failed to fetch template");
+    console.error(e);
+    process.exit(1);
+  }
+
+  const hasPackageJson = fs.existsSync(path.join(dest, "package.json"));
+
+  await finalizeProject(dest, answers.name, {
+    install: hasPackageJson ? !!answers.install : false,
+    git: !!answers.git,
+    pm: (argv.pm as "npm" | "yarn" | "pnpm" | "bun" | undefined),
+  });
+
+  console.log(`\n${kleur.bold("Done!")} Created ${kleur.cyan(answers.name)} at ${kleur.gray(dest)}\n`);
+  console.log(kleur.bold("Next steps:"));
+  console.log(`  cd ${answers.name}`);
+
+  if (hasPackageJson) {
+    const pm = (argv.pm || "npm") as "npm" | "yarn" | "pnpm" | "bun";
+    const commands: Record<typeof pm, [string, string]> = {
+      npm: ["npm install", "npm run dev"],
+      yarn: ["yarn install", "yarn dev"],
+      pnpm: ["pnpm install", "pnpm dev"],
+      bun: ["bun install", "bun dev"],
+    };
+
+    const [installCmd, devCmd] = commands[pm] || commands.npm;
+
+    if (!answers.install) console.log(`  ${installCmd}`);
+    console.log(`  ${devCmd}\n`);
+  } else {
+    console.log(`  Open ${kleur.cyan("index.html")} in your browser.`);
+    console.log(`  Or serve locally:\n    - live-server\n    - python3 -m http.server\n`);
+  }
+
+  process.exit(0);
+})();

--- a/src/postInstall.ts
+++ b/src/postInstall.ts
@@ -1,0 +1,49 @@
+// src/postInstall.ts
+
+import { execa } from "execa";
+import fs from "node:fs";
+import path from "node:path";
+
+function detectPM(explicit?: string) {
+  if (explicit) return explicit;
+  const ua = process.env.npm_config_user_agent || "";
+  if (ua.startsWith("pnpm")) return "pnpm";
+  if (ua.startsWith("yarn")) return "yarn";
+  if (ua.startsWith("bun"))  return "bun";
+  return "npm";
+}
+
+export async function finalizeProject(
+  dest: string,
+  name: string,
+  opts: { install: boolean; git: boolean; pm?: "npm"|"yarn"|"pnpm"|"bun" }
+) {
+  const pkgPath = path.join(dest, "package.json");
+  if (fs.existsSync(pkgPath)) {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+    const safe = name
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/[^a-z0-9-_.]/g, "");
+    pkg.name = safe || "my-app";
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+  }
+
+  if (opts.git && !fs.existsSync(path.join(dest, ".git"))) {
+    await execa("git", ["init", "-b", "main"], { cwd: dest });
+    await execa("git", ["add", "-A"], { cwd: dest });
+    await execa("git", ["commit", "-m", "chore: initial scaffold with jirehgrp"], { cwd: dest })
+      .catch(() => {});
+  }
+
+  if (opts.install && fs.existsSync(pkgPath)) {
+    const pm = detectPM(opts.pm);
+    const installCmd =
+      pm === "yarn" ? ["yarn"] :
+      pm === "pnpm" ? ["pnpm","install"] :
+      pm === "bun"  ? ["bun","install"] :
+                      ["npm","install"];
+    await execa(installCmd[0], installCmd.slice(1), { cwd: dest, stdio: "inherit" });
+  }
+}

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,0 +1,54 @@
+// src/prompts.ts
+
+import prompts from "prompts";
+import { registry } from "./registry.js";
+
+export type Answers = {
+  name: string;
+  templateKey: keyof typeof registry;
+  install: boolean;
+  git: boolean;
+};
+
+export async function ask(opts: Partial<Answers>): Promise<Answers> {
+  const templateChoices = Object.entries(registry).map(([key, v]) => ({
+    title: v.label,
+    value: key
+  }));
+
+  const res = await prompts(
+    [
+      {
+        name: "name",
+        type: opts.name ? null : "text",
+        message: "Project name:",
+        initial: "my-app"
+      },
+      {
+        name: "templateKey",
+        type: opts.templateKey ? null : "select",
+        message: "Select a template:",
+        choices: templateChoices
+      },
+      {
+        name: "install",
+        type: typeof opts.install === "boolean" ? null : "toggle",
+        message: "Install dependencies?",
+        active: "yes",
+        inactive: "no",
+        initial: true
+      },
+      {
+        name: "git",
+        type: typeof opts.git === "boolean" ? null : "toggle",
+        message: "Initialize git?",
+        active: "yes",
+        inactive: "no",
+        initial: true
+      }
+    ],
+    { onCancel: () => process.exit(1) }
+  );
+
+  return { ...opts, ...res } as Answers;
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,53 @@
+// src/registry.ts
+
+type TemplateId =
+  | "nextjs"
+  | "react-vite/js"
+  | "react-vite/ts"
+  | "vanilla/js"
+  | "vanilla/ts"
+  | "vanilla-vite/js"
+  | "vanilla-vite/ts";
+
+export type Registry = Record<
+  TemplateId,
+  { label: string; repo: string; subdir?: string; ref?: string }
+>;
+
+export const registry: Registry = {
+  "nextjs": {
+    label: "Next.js (TS)",
+    repo: "jirehgrp-org/jirehgrp-templates#v1.0.0",
+    subdir: "templates/nextjs"
+  },
+  "react-vite/js": {
+    label: "React + Vite (JS)",
+    repo: "jirehgrp-org/jirehgrp-templates#v1.0.0",
+    subdir: "templates/react-vite/js"
+  },
+  "react-vite/ts": {
+    label: "React + Vite (TS)",
+    repo: "jirehgrp-org/jirehgrp-templates#v1.0.0",
+    subdir: "templates/react-vite/ts"
+  },
+  "vanilla/js": {
+    label: "Vanilla (JS)",
+    repo: "jirehgrp-org/jirehgrp-templates#v1.0.0",
+    subdir: "templates/vanilla/js"
+  },
+  "vanilla/ts": {
+    label: "Vanilla (TS)",
+    repo: "jirehgrp-org/jirehgrp-templates#v1.0.0",
+    subdir: "templates/vanilla/ts"
+  },
+  "vanilla-vite/js": {
+    label: "Vanilla + Vite (JS)",
+    repo: "jirehgrp-org/jirehgrp-templates#v1.0.0",
+    subdir: "templates/vanilla/vite/js"
+  },
+  "vanilla-vite/ts": {
+    label: "Vanilla + Vite (TS)",
+    repo: "jirehgrp-org/jirehgrp-templates#v1.0.0",
+    subdir: "templates/vanilla/vite/ts"
+  }
+};

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -1,0 +1,88 @@
+// src/tree.ts
+
+import fs from 'fs';
+import path from 'path';
+import kleur from 'kleur';
+
+export interface TreeOptions {
+  ignore?: string[];
+  color?: boolean;
+}
+
+function loadIgnoreList(): string[] {
+  return [
+    'node_modules', '.git', 'dist', 'build', 'out', 'coverage', '.cache', '.parcel-cache',
+    'npm-debug.log', 'yarn-error.log', 'pnpm-debug.log', 'package-lock.json',
+    '.DS_Store', 'Thumbs.db',
+    '.next',
+    '__pycache__', '*.py[cod]', '*.egg-info', '.pytest_cache', '.mypy_cache',
+    'log', 'tmp', 'vendor/bundle', '.byebug_history',
+    'vendor', '.env', '.env.*', 'storage',
+    'db.sqlite3', 'media',
+    'target', '*.class', '*.jar', '*.war', '*.ear',
+    '.vscode', '.idea', '*.iml',
+    '*.log',
+  ];
+}
+
+function buildTreeString(
+  dirPath: string,
+  prefix = '',
+  options: TreeOptions = {}
+): string {
+  const ignoreList = options.ignore || loadIgnoreList();
+  const useColor = options.color !== false;  // default true
+
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true })
+    .filter(item => !ignoreList.includes(item.name));
+
+  const dirs = entries.filter(e => e.isDirectory()).sort((a, b) => a.name.localeCompare(b.name));
+  const files = entries.filter(e => !e.isDirectory()).sort((a, b) => a.name.localeCompare(b.name));
+  const items = [...dirs, ...files];
+
+  let treeString = '';
+
+  items.forEach((item, index) => {
+    const isLast = index === items.length - 1;
+    const connector = isLast ? '└── ' : '├── ';
+    let name = item.name + (item.isDirectory() ? '/' : '');
+
+    if (useColor) {
+      name = item.isDirectory() ? kleur.cyan(name).toString() : kleur.white(name).toString();
+    }
+
+    treeString += prefix + connector + name + '\n';
+
+    if (item.isDirectory()) {
+      const newPrefix = prefix + (isLast ? '    ' : '│   ');
+      treeString += buildTreeString(path.join(dirPath, item.name), newPrefix, options);
+    }
+  });
+
+  return treeString;
+}
+
+export function writeTreeToFile(
+  dirPath: string,
+  options: TreeOptions = {}
+): string {
+  // force color false for file output
+  const treeString = buildTreeString(dirPath, '', { ...options, color: false });
+
+  const structurePath = path.join(dirPath, 'structure.txt');
+  const projectStructurePath = path.join(dirPath, 'project_structure.txt');
+
+  let filePathToWrite: string;
+
+  if (fs.existsSync(structurePath)) {
+    filePathToWrite = projectStructurePath;
+  } else {
+    filePathToWrite = structurePath;
+  }
+
+  fs.writeFileSync(filePathToWrite, treeString);
+
+  return filePathToWrite;
+}
+
+export { buildTreeString };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
+    "preserveSymlinks": false,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
**Description:**
This PR introduces the new `jirehgrp` CLI tool as a replacement for the previous `create-jireh` package. Starting fresh at version `0.0.1`, this CLI enables scaffolding frontend projects from Jireh Group templates with support for multiple frameworks, multilingual and theme toggling features, and a rich interactive experience.

**Key changes:**

* New repository structure under `jirehgrp-cli`
* Updated package name to `jirehgrp` with CLI command `jirehgrp`
* Supports Next.js, React+Vite, Vue3+Vite, SvelteKit+Vite, and Vanilla JS/TS templates
* Interactive prompts for project name, template selection, package manager, git initialization, and more
* New `--tree` flag for generating a project folder structure file
* Updated documentation and README for new usage and options
* Set minimum Node.js version to 18
* Prepared for npm publish under the new package name

This lays the foundation for future enhancements and improved template management.